### PR TITLE
Remove unused imports

### DIFF
--- a/src/src/screens/DifficultyScreen.tsx
+++ b/src/src/screens/DifficultyScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import styled from 'styled-components/native';
 import MultiSlider from '@ptomasroos/react-native-multi-slider';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
@@ -75,8 +75,10 @@ const DifficultyScreen: React.FC = () => {
         containerStyle={{ marginHorizontal: 16 }}
       />
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginTop: 8 }}>
-        {DIFFICULTY_LABELS.map((label, idx) => (
-          <RangeText key={label} style={{ fontSize: 14, color: theme.colors.text }}>{label.charAt(0).toUpperCase() + label.slice(1)}</RangeText>
+        {DIFFICULTY_LABELS.map((label) => (
+          <RangeText key={label} style={{ fontSize: 14, color: theme.colors.text }}>
+            {label.charAt(0).toUpperCase() + label.slice(1)}
+          </RangeText>
         ))}
       </View>
       <NextButton enabled onPress={handleNext}>

--- a/src/src/screens/GameScreen.tsx
+++ b/src/src/screens/GameScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { View, Text, TextInput, TouchableOpacity, Image, StyleSheet, FlatList } from 'react-native';
+import { View, Text, TouchableOpacity, FlatList } from 'react-native';
 import { Audio } from 'expo-av';
 import { useRoute } from '@react-navigation/native';
 import styled from 'styled-components/native';
@@ -64,7 +64,7 @@ const SheetHandle = styled.View`
 
 const GameScreen: React.FC = () => {
   const route = useRoute<any>();
-  const { teams, genres, decades, difficultyRange, tracks } = route.params || {};
+  const { teams, tracks } = route.params || {};
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0);
   const [sound, setSound] = useState<Audio.Sound | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -102,8 +102,11 @@ const GameScreen: React.FC = () => {
 
   React.useEffect(() => {
     loadAudio();
-    return () => { if (sound) sound.unloadAsync(); };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      if (sound) {
+        sound.unloadAsync();
+      }
+    };
   }, [currentTrackIndex]);
 
   const togglePlayPause = async () => {

--- a/src/src/screens/GenreScreen.tsx
+++ b/src/src/screens/GenreScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, ActivityIndicator, Alert } from 'react-native';
+import { ActivityIndicator } from 'react-native';
 import styled from 'styled-components/native';
 import { useNavigation, useRoute, NavigationProp } from '@react-navigation/native';
 import theme from '../theme';
@@ -63,7 +63,7 @@ const GenreScreen: React.FC = () => {
   const { teams, difficultyRange } = (route.params || {}) as any;
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
   const [selectedDecades, setSelectedDecades] = useState<string[]>([]);
-  const [loading, setLoading] = useState(false);
+  const loading = false;
 
   const toggleGenre = (genre: string) => {
     setSelectedGenres(prev =>

--- a/src/src/screens/ResultsScreen.tsx
+++ b/src/src/screens/ResultsScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, FlatList } from 'react-native';
+import { Text, FlatList } from 'react-native';
 import styled from 'styled-components/native';
 import theme from '../theme';
 

--- a/src/src/screens/TeamSelectScreen.tsx
+++ b/src/src/screens/TeamSelectScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { FlatList, Text } from 'react-native';
 import styled from 'styled-components/native';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
-import { useTeams, Team } from '../context/TeamContext';
+import { useTeams } from '../context/TeamContext';
 import theme from '../theme';
 import { RootStackParamList } from '../types';
 

--- a/src/src/screens/TeamsScreen.tsx
+++ b/src/src/screens/TeamsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { FlatList, Modal, View, Text, TouchableOpacity, TextInput, StyleSheet } from 'react-native';
+import { FlatList, Modal, View, Text } from 'react-native';
 import styled from 'styled-components/native';
 import { useTeams, Team } from '../context/TeamContext';
 import theme from '../theme';


### PR DESCRIPTION
## Summary
- clean up unused imports in screen components

## Testing
- `npx eslint . --ext .ts,.tsx --no-eslintrc --parser @typescript-eslint/parser --rule "no-unused-vars:[error,{args:'none'}]"`

------
https://chatgpt.com/codex/tasks/task_e_6851ac0bd96c832ebe58940e27bec0b8