### PR TITLE
Add navigation types

### DIFF
--- a/src/src/screens/DifficultyScreen.tsx
+++ b/src/src/screens/DifficultyScreen.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native';
 import MultiSlider from '@ptomasroos/react-native-multi-slider';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import theme from '../theme';
-import { RootStackParamList } from '../types';
+import { RootStackParamList } from '../../types';
 
 const DIFFICULTY_LABELS = ['easy', 'medium', 'hard', 'expert'] as const;
 type Difficulty = typeof DIFFICULTY_LABELS[number];

--- a/src/src/screens/GenreScreen.tsx
+++ b/src/src/screens/GenreScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, ActivityIndicator, Alert } from 'react-native';
 import styled from 'styled-components/native';
 import { useNavigation, useRoute, NavigationProp } from '@react-navigation/native';
 import theme from '../theme';
-import { RootStackParamList } from '../types';
+import { RootStackParamList } from '../../types';
 
 const genresList = [
   'Pop', 'Rock', 'Hip-Hop', 'Electronic', 'Jazz', 'Classical', 'Country', 'R&B', 'Indie', 'Metal'

--- a/src/src/screens/TeamSelectScreen.tsx
+++ b/src/src/screens/TeamSelectScreen.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/native';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import { useTeams, Team } from '../context/TeamContext';
 import theme from '../theme';
-import { RootStackParamList } from '../types';
+import { RootStackParamList } from '../../types';
 
 const Container = styled.View`
   flex: 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+import { Team } from './src/context/TeamContext';
+
+export type RootStackParamList = {
+  DifficultyScreen: { teams: Team[] };
+  Genre: { teams: Team[]; difficultyRange: [string, string] };
+  Game: {
+    teams: Team[];
+    genres: string[];
+    decades: string[];
+    difficultyRange: [string, string];
+  };
+};


### PR DESCRIPTION
## Summary
- define `RootStackParamList` in a new `src/types.ts`
- update screen imports to use the new type location

## Testing
- `npm run lint` *(fails: No files matching the pattern)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac0853a4832eb997757fada53b2e