### PR TITLE
Configure Babel for Expo

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,1 +1,4 @@
- 
+module.exports = function(api) {
+  api.cache(true);
+  return { presets: ['babel-preset-expo'] };
+};


### PR DESCRIPTION
## Summary
- configure `babel.config.js` for Expo and React Native

## Testing
- `npm install`
- `npm run lint` *(fails: No files matching the pattern "../src/**/*.{ts,tsx}" were found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac00814c832ea3831362a50c9f2a